### PR TITLE
Fix leaky test

### DIFF
--- a/test/system/workarea/admin/in_grid_content_system_test.rb
+++ b/test/system/workarea/admin/in_grid_content_system_test.rb
@@ -35,10 +35,10 @@ module Workarea
         assert(page.has_selector?('.content-block'))
 
         preview_frame = page.find('.content-block__iframe')
-        switch_to_frame(preview_frame) do |frame|
-          assert(frame.has_selector?('.grid'))
-          assert(frame.has_selector?('.grid__cell'), count: Workarea.config.grid_cell_content_preview_cells)
-          assert(frame.has_selector?('.product-grid-cell-content-block'))
+        within_frame(preview_frame) do
+          assert(page.has_selector?('.grid'))
+          assert(page.has_selector?('.grid__cell'), count: Workarea.config.grid_cell_content_preview_cells)
+          assert(page.has_selector?('.product-grid-cell-content-block'))
         end
       end
 


### PR DESCRIPTION
`switch_to_frame` doesn't take a block, and the caller is responsible
for switching back to the previous frame.  Fix test to correctly use
`within_frame`.