### PR TITLE
Add x-wide media query to address display issue

### DIFF
--- a/app/assets/stylesheets/workarea/product_grid_content/components/_content_block_product_grid_cell.scss
+++ b/app/assets/stylesheets/workarea/product_grid_content/components/_content_block_product_grid_cell.scss
@@ -36,7 +36,9 @@
     }
 
     &.content-block--hidden-for-x-wide {
-        display: none;
+        @include respond-to($x-wide-breakpoint) {
+            display: none;
+        }
     }
 
     .grid--flush & {


### PR DESCRIPTION
Without this media query, when display setting is set to `Hide for x-wide` the content block never displays.