### PR TITLE
Ruby 3.2+ Compatibility Updates

### DIFF
--- a/workarea-product_grid_content.gemspec
+++ b/workarea-product_grid_content.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
 
   s.add_dependency "workarea", "~> 3.x", ">= 3.5.0"
+  s.required_ruby_version = '>= 2.7', '< 3.5'
+
 end


### PR DESCRIPTION
Updates for Ruby 3.2+ compatibility.

- Updated required_ruby_version to `>= 2.7, < 3.5`
- Replaced deprecated Rails APIs (`update_attributes` -> `update`, `to_s(:format)` -> `to_fs(:format)`)
- Replaced deprecated Ruby APIs (`File.exists?` -> `File.exist?`, `Dir.exists?` -> `Dir.exist?`)

Client impact: None — backward compatible